### PR TITLE
Handle SSM parameter batching in backend config

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,27 @@ The Vite dev server runs on `http://localhost:5173` and proxies API calls to the
 
 The proxy container publishes port 80 and serves the React SPA while forwarding `/api/*` to the backend service.
 
+## Troubleshooting
+
+### AWS SSO login validation error
+
+If `aws sso login --profile n11817143-a2` fails with an error similar to:
+
+```
+1 validation error detected: Value 'ap-southeast-2_ABC123clientid' at 'clientId' failed to satisfy constraint: Member must satisfy regular expression pattern: [\w+]+
+```
+
+it means the SSO `clientId` being sent to AWS contains characters that do not match the allowed pattern. The AWS CLI automatically stores the correct client registration (an alphanumeric/underscore ID) under `~/.aws/sso/cache/`. Re-run `aws configure sso` and select the existing `n11817143-a2` profile so that the CLI refreshes the cached registration instead of reusing a manually edited value with hyphens. After refreshing the profile, retry `aws sso login`.
+
+### Route53 host name is not used by the app
+
+The frontend reads `VITE_API_URL` from `.env` (see `client/.env.example`) and uses that value for every API request. At runtime it also fetches `/config` from the backend, which returns the Cognito Hosted UI domain that was loaded from Parameter Store (`/n11817143/app/domainName`). If either of these values points at the raw EC2 hostname instead of `https://n11817143-videoapp.cab432.com`, the browser will keep using the EC2 endpoint. Make sure:
+
+1. The `.env` file in the frontend container/environment sets `VITE_API_URL=https://n11817143-videoapp.cab432.com/api`.
+2. The Parameter Store key `/n11817143/app/domainName` is set to the same Route53 host.
+
+With both settings in place, the SPA will call the API via the Route53 alias and Amplify will initialise Cognito using the custom domain reported by `/config`.
+
 ## Requirements
 
 - Generate complete backend code (`server/`) and frontend code (`client/`).

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -20,18 +20,30 @@ const PARAMETER_NAMES = [
 
 let cachedConfig = null;
 
+const PARAMETER_BATCH_SIZE = 10;
+
 async function fetchParameters() {
   const ssm = new SSMClient({ region: REGION });
-  const response = await ssm.send(
-    new GetParametersCommand({ Names: PARAMETER_NAMES, WithDecryption: true })
-  );
 
   const values = {};
-  (response.Parameters || []).forEach((param) => {
-    values[param.Name] = param.Value;
-  });
+  const invalidParameters = new Set();
 
-  const missing = PARAMETER_NAMES.filter((name) => !values[name]);
+  for (let i = 0; i < PARAMETER_NAMES.length; i += PARAMETER_BATCH_SIZE) {
+    const batch = PARAMETER_NAMES.slice(i, i + PARAMETER_BATCH_SIZE);
+    const response = await ssm.send(
+      new GetParametersCommand({ Names: batch, WithDecryption: true })
+    );
+
+    (response.Parameters || []).forEach((param) => {
+      values[param.Name] = param.Value;
+    });
+
+    (response.InvalidParameters || []).forEach((name) => invalidParameters.add(name));
+  }
+
+  const missing = PARAMETER_NAMES.filter(
+    (name) => !values[name] || invalidParameters.has(name)
+  );
   if (missing.length) {
     throw new Error(`Missing SSM parameters: ${missing.join(", ")}`);
   }


### PR DESCRIPTION
## Summary
- batch SSM parameter retrieval so the backend respects the 10-name limit per request
- surface invalid or missing parameters after fetching all batches

## Testing
- not run (no automated tests available)


------
https://chatgpt.com/codex/tasks/task_e_68d7dc3f4504832d8596869bb826400a