### PR TITLE
Add Cache-Control header for API responses

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -7,6 +7,11 @@ import { getConfig } from "./config.js";
 
 const app = express();
 
+app.use((_req, res, next) => {
+  res.set("Cache-Control", "no-store");
+  next();
+});
+
 app.use(cors());
 app.use(express.json({ limit: "10mb" }));
 app.use(morgan("combined"));


### PR DESCRIPTION
## Summary
- add middleware to set a no-store Cache-Control header on every API response

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e325d95c832d877a96a1b14c37aa