### PR TITLE
Refresh tokens before video API requests

### DIFF
--- a/client/src/api/client.js
+++ b/client/src/api/client.js
@@ -1,5 +1,12 @@
 const API_URL = import.meta.env.VITE_API_URL;
 
+async function resolveTokens(tokensOrProvider) {
+  if (typeof tokensOrProvider === "function") {
+    return tokensOrProvider();
+  }
+  return tokensOrProvider;
+}
+
 function buildHeaders(tokens, extra = {}) {
   const headers = {
     "Content-Type": "application/json",
@@ -30,6 +37,7 @@ async function handleResponse(response) {
 }
 
 export async function createVideo({ title, file, tokens }) {
+  const resolvedTokens = await resolveTokens(tokens);
   const body = {
     title,
     filename: file.name,
@@ -39,7 +47,7 @@ export async function createVideo({ title, file, tokens }) {
 
   const response = await fetch(`${API_URL}/videos`, {
     method: "POST",
-    headers: buildHeaders(tokens),
+    headers: buildHeaders(resolvedTokens),
     body: JSON.stringify(body)
   });
 
@@ -61,25 +69,28 @@ export async function uploadToS3(uploadUrl, file) {
 }
 
 export async function listVideos(tokens, params = {}) {
+  const resolvedTokens = await resolveTokens(tokens);
   const search = new URLSearchParams(params).toString();
   const url = search ? `${API_URL}/videos?${search}` : `${API_URL}/videos`;
   const response = await fetch(url, {
-    headers: buildHeaders(tokens)
+    headers: buildHeaders(resolvedTokens)
   });
   return handleResponse(response);
 }
 
 export async function getVideo(id, tokens) {
+  const resolvedTokens = await resolveTokens(tokens);
   const response = await fetch(`${API_URL}/videos/${id}`, {
-    headers: buildHeaders(tokens)
+    headers: buildHeaders(resolvedTokens)
   });
   return handleResponse(response);
 }
 
 export async function deleteVideo(id, tokens) {
+  const resolvedTokens = await resolveTokens(tokens);
   const response = await fetch(`${API_URL}/videos/${id}`, {
     method: "DELETE",
-    headers: buildHeaders(tokens)
+    headers: buildHeaders(resolvedTokens)
   });
   return handleResponse(response);
 }

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -58,22 +58,35 @@ export function AuthProvider({ children }) {
     return configurePromiseRef.current;
   }, [amplifyReady]);
 
+  const refreshTokens = useCallback(async () => {
+    try {
+      await ensureAmplify();
+      const session = await Auth.currentSession();
+      const currentUser = await Auth.currentAuthenticatedUser();
+      const idToken = session.getIdToken().getJwtToken();
+      const accessToken = session.getAccessToken().getJwtToken();
+      const nextTokens = { idToken, accessToken };
+      setTokens(nextTokens);
+      setUser({
+        username: currentUser.getUsername(),
+        attributes: currentUser.attributes
+      });
+      return nextTokens;
+    } catch (err) {
+      setUser(null);
+      setTokens(null);
+      if (err?.message && err.message !== "No current user") {
+        console.error("Failed to refresh auth tokens", err);
+      }
+      throw err;
+    }
+  }, [ensureAmplify]);
+
   useEffect(() => {
     const bootstrap = async () => {
       try {
-        await ensureAmplify();
-        const session = await Auth.currentSession();
-        const currentUser = await Auth.currentAuthenticatedUser();
-        const idToken = session.getIdToken().getJwtToken();
-        const accessToken = session.getAccessToken().getJwtToken();
-        setTokens({ idToken, accessToken });
-        setUser({
-          username: currentUser.getUsername(),
-          attributes: currentUser.attributes
-        });
+        await refreshTokens();
       } catch (err) {
-        setUser(null);
-        setTokens(null);
         if (err?.message && err.message !== "No current user") {
           console.error("Failed to restore user session", err);
         }
@@ -83,21 +96,13 @@ export function AuthProvider({ children }) {
     };
 
     bootstrap();
-  }, [ensureAmplify]);
+  }, [refreshTokens]);
 
   const signIn = async (username, password) => {
     setError(null);
     await ensureAmplify();
     await Auth.signIn({ username, password });
-    const session = await Auth.currentSession();
-    const currentUser = await Auth.currentAuthenticatedUser();
-    const idToken = session.getIdToken().getJwtToken();
-    const accessToken = session.getAccessToken().getJwtToken();
-    setTokens({ idToken, accessToken });
-    setUser({
-      username: currentUser.getUsername(),
-      attributes: currentUser.attributes
-    });
+    await refreshTokens();
   };
 
   const signUp = async ({ username, password, email }) => {
@@ -132,12 +137,13 @@ export function AuthProvider({ children }) {
       error,
       groups,
       signIn,
+      refreshTokens,
       signOut,
       signUp,
       confirmSignUp,
       setError
     }),
-    [user, tokens, loading, error, groups]
+    [user, tokens, loading, error, groups, refreshTokens]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/client/src/pages/AdminPage.jsx
+++ b/client/src/pages/AdminPage.jsx
@@ -4,7 +4,7 @@ import { Toast } from "../components/Toast.jsx";
 import { useAuth } from "../context/AuthContext.jsx";
 
 export function AdminPage() {
-  const { tokens, groups } = useAuth();
+  const { tokens, groups, refreshTokens } = useAuth();
   const isAdmin = groups.includes("admins");
   const [videos, setVideos] = useState([]);
   const [error, setError] = useState("");
@@ -14,7 +14,7 @@ export function AdminPage() {
     if (!isAdmin) return;
     const load = async () => {
       try {
-        const data = await listVideos(tokens, { scope: "all" });
+        const data = await listVideos(refreshTokens, { scope: "all" });
         setVideos(data.items || []);
       } catch (err) {
         setError(err.message);
@@ -22,12 +22,12 @@ export function AdminPage() {
     };
 
     load();
-  }, [tokens, isAdmin]);
+  }, [tokens, isAdmin, refreshTokens]);
 
   const handleDelete = async (videoId) => {
     if (!window.confirm("Delete this video and all related assets?")) return;
     try {
-      await deleteVideo(videoId, tokens);
+      await deleteVideo(videoId, refreshTokens);
       setVideos((prev) => prev.filter((video) => video.videoId !== videoId));
       setMessage("Video deleted successfully");
     } catch (err) {

--- a/client/src/pages/UploadPage.jsx
+++ b/client/src/pages/UploadPage.jsx
@@ -5,7 +5,7 @@ import { Toast } from "../components/Toast.jsx";
 import { useAuth } from "../context/AuthContext.jsx";
 
 export function UploadPage() {
-  const { tokens } = useAuth();
+  const { tokens, refreshTokens } = useAuth();
   const [file, setFile] = useState(null);
   const [title, setTitle] = useState("");
   const [status, setStatus] = useState("");
@@ -21,7 +21,14 @@ export function UploadPage() {
 
     try {
       setStatus("Requesting upload URL...");
-      const { uploadUrl, videoId } = await createVideo({ title, file, tokens });
+      if (!tokens) {
+        throw new Error("You must be signed in to upload a video.");
+      }
+      const { uploadUrl, videoId } = await createVideo({
+        title,
+        file,
+        tokens: refreshTokens
+      });
       setStatus("Uploading to S3...");
       await uploadToS3(uploadUrl, file);
       setStatus("Upload completed. Transcoding will begin shortly.");

--- a/client/src/pages/VideosPage.jsx
+++ b/client/src/pages/VideosPage.jsx
@@ -4,15 +4,19 @@ import { useAuth } from "../context/AuthContext.jsx";
 import { Toast } from "../components/Toast.jsx";
 
 export function VideosPage() {
-  const { tokens } = useAuth();
+  const { tokens, refreshTokens } = useAuth();
   const [videos, setVideos] = useState([]);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     const load = async () => {
+      if (!tokens) {
+        setLoading(false);
+        return;
+      }
       try {
-        const data = await listVideos(tokens);
+        const data = await listVideos(refreshTokens);
         setVideos(data.items || []);
       } catch (err) {
         console.error(err);
@@ -23,7 +27,7 @@ export function VideosPage() {
     };
 
     load();
-  }, [tokens]);
+  }, [tokens, refreshTokens]);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary
- add a refresh helper in the auth context that always fetches the latest Cognito session tokens before use
- update the video API client and pages to call the helper so authorization headers are populated with fresh tokens for every request

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ebb605dc832d831ab1d681709227