### PR TITLE
Add default API base path when VITE_API_URL is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Namespaced under `/n11817143/app/`:
   - Video list: fetch metadata from API, show thumbnails + play via signed URL.
   - Admin dashboard: delete videos.
 - `.env` for frontend:
-  - `VITE_API_URL=https://n11817143-videoapp.cab432.com/api`
+  - `VITE_API_URL=https://n11817143-videoapp.cab432.com/api` (optional; falls back to `/api` when the frontend and backend share a host)
   - Cognito settings are fetched at runtime from the backend via `/config`.
 - Dockerfile for frontend.
 

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,1 +1,2 @@
+# Optional: override the default `/api` base path when the backend is hosted elsewhere
 VITE_API_URL=https://n11817143-videoapp.cab432.com/api

--- a/client/src/api/client.js
+++ b/client/src/api/client.js
@@ -1,4 +1,6 @@
-const API_URL = import.meta.env.VITE_API_URL;
+import { getApiBaseUrl } from "../config";
+
+const API_URL = getApiBaseUrl();
 
 async function resolveTokens(tokensOrProvider) {
   if (typeof tokensOrProvider === "function") {

--- a/client/src/awsConfig.js
+++ b/client/src/awsConfig.js
@@ -1,3 +1,5 @@
+import { getApiBaseUrl } from "./config";
+
 let cachedConfig = null;
 let configPromise = null;
 
@@ -7,10 +9,7 @@ function normaliseDomain(domain) {
 }
 
 async function requestConfigFromApi() {
-  const apiUrl = import.meta.env.VITE_API_URL;
-  if (!apiUrl) {
-    throw new Error("VITE_API_URL is not defined. Update your frontend environment configuration.");
-  }
+  const apiUrl = getApiBaseUrl();
 
   const response = await fetch(`${apiUrl}/config`, {
     headers: {

--- a/client/src/config.js
+++ b/client/src/config.js
@@ -1,0 +1,17 @@
+const DEFAULT_API_BASE_PATH = "/api";
+
+function normaliseBaseUrl(url) {
+  if (!url) return "";
+  return url.replace(/\/+$/, "");
+}
+
+export function getApiBaseUrl() {
+  const envValue = typeof import.meta !== "undefined" ? import.meta.env?.VITE_API_URL : undefined;
+  const trimmed = typeof envValue === "string" ? envValue.trim() : "";
+  const baseUrl = trimmed || DEFAULT_API_BASE_PATH;
+  const normalised = normaliseBaseUrl(baseUrl);
+  if (!normalised) {
+    throw new Error("API base URL could not be determined. Set VITE_API_URL or configure a proxy at '/api'.");
+  }
+  return normalised;
+}


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the API base URL with a `/api` fallback when `VITE_API_URL` is not set
- update the API client and AWS configuration loader to use the shared helper
- document the optional nature of `VITE_API_URL` in the frontend README entry and `.env` example

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d7ffe191c0832dba7ab604e63d9e17