### PR TITLE
Handle Cognito client secret in config

### DIFF
--- a/client/src/awsConfig.js
+++ b/client/src/awsConfig.js
@@ -29,7 +29,7 @@ async function requestConfigFromApi() {
   }
 
   const data = await response.json();
-  const { region, userPoolId, userPoolClientId, domain } = data;
+  const { region, userPoolId, userPoolClientId, userPoolClientSecret, domain } = data;
 
   if (!region || !userPoolId || !userPoolClientId) {
     throw new Error("Incomplete Cognito configuration received from API.");
@@ -41,6 +41,10 @@ async function requestConfigFromApi() {
     userPoolWebClientId: userPoolClientId,
     mandatorySignIn: true
   };
+
+  if (userPoolClientSecret) {
+    authConfig.clientSecret = userPoolClientSecret;
+  }
 
   const normalisedDomain = normaliseDomain(domain);
   if (normalisedDomain) {

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -27,6 +27,7 @@ app.get("/config", async (_req, res, next) => {
       region: config.region,
       userPoolId: config.cognitoUserPoolId,
       userPoolClientId: config.cognitoClientId,
+      userPoolClientSecret: config.cognitoClientSecret,
       domain: config.domainName
     });
   } catch (error) {

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -75,7 +75,8 @@ async function fetchSecrets() {
 
   const parsed = JSON.parse(secretValue.SecretString);
   return {
-    jwtSecret: parsed.JWT_SECRET
+    jwtSecret: parsed.JWT_SECRET,
+    cognitoClientSecret: parsed.COGNITO_CLIENT_SECRET
   };
 }
 


### PR DESCRIPTION
## Summary
- expose the Cognito app client secret from the backend configuration endpoint when provided
- pass the optional client secret through the frontend AWS Amplify config to enable secret hash usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d822309260832d95663fed7cb9c488